### PR TITLE
fix: improve shell script reliability for dev environment

### DIFF
--- a/scripts/dev-with-logs.sh
+++ b/scripts/dev-with-logs.sh
@@ -319,8 +319,12 @@ EOF
 
   print_status "cyan" "🦀 Press Ctrl+C to swim away and shut down all components."
 
-  # Wait for all component processes to finish
-  wait ${COMPONENT_PIDS[@]}
+  # Instead of waiting for processes that might have been started in subshells,
+  # we keep the script running until user presses Ctrl+C, which will trigger the cleanup
+  # Use a simple infinite loop that doesn't consume CPU
+  while true; do
+    sleep 1
+  done
 else
   print_status "red" "
 =================================================


### PR DESCRIPTION
## Summary
- Fix shell script error in dev-with-logs.sh when handling background processes
- Prevent error about PIDs not being children of this shell
- Improve script reliability for interactive development

## Technical Details
- Replaced problematic wait command with reliable infinite loop
- Script now properly handles Ctrl+C termination
- Ensures clean process cleanup on exit through existing trap handlers
- Background processes continue running correctly until terminated

## Test plan
- Verified script runs without errors on Node.js v22.14.0
- Confirmed components start correctly and error output is eliminated
- Tested Ctrl+C functionality for proper cleanup of all processes